### PR TITLE
Added a test-set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: c
+
+before_install:
+  - mkdir -p /tmp/scratch
+
+install:
+  - ./tools/install-chibi
+  - ./tools/install-self
+
+script:
+  - ./tools/run-all-tests

--- a/srfi-60/srfi/60.sld
+++ b/srfi-60/srfi/60.sld
@@ -1,0 +1,11 @@
+(define-library (srfi 60)
+  (export logand logior logxor lognot logtest logcount logbit?
+   bitwise-and bitwise-ior bitwise-xor bitwise-not bitwise-if
+   bitwise-merge ash arithmetic-shift bit-count bit-set? copy-bit
+   any-bits-set? log2-binary-factors first-set-bit integer-length
+   bit-field copy-bit-field rotate-bit-field reverse-bit-field
+   integer->list list->integer booleans->integer)
+
+  (import (scheme base))
+
+  (include "60/reference-implementation.scm"))

--- a/srfi-60/srfi/60/reference-implementation.scm
+++ b/srfi-60/srfi/60/reference-implementation.scm
@@ -1,0 +1,237 @@
+;;;; "logical.scm", bit access and operations for integers for Scheme
+;;; Copyright (C) 1991, 1993, 2001, 2003, 2005 Aubrey Jaffer
+;
+;Permission to copy this software, to modify it, to redistribute it,
+;to distribute modified versions, and to use it for any purpose is
+;granted, subject to the following restrictions and understandings.
+;
+;1.  Any copy made of this software must include this copyright notice
+;in full.
+;
+;2.  I have made no warranty or representation that the operation of
+;this software will be error-free, and I am under no obligation to
+;provide any services, by way of maintenance, update, or otherwise.
+;
+;3.  In conjunction with products arising from the use of this
+;material, there shall be no use of my name in any advertising,
+;promotional, or sales literature without prior written consent in
+;each case.
+
+(define logical:boole-xor
+ '#(#(0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15)
+    #(1 0 3 2 5 4 7 6 9 8 11 10 13 12 15 14)
+    #(2 3 0 1 6 7 4 5 10 11 8 9 14 15 12 13)
+    #(3 2 1 0 7 6 5 4 11 10 9 8 15 14 13 12)
+    #(4 5 6 7 0 1 2 3 12 13 14 15 8 9 10 11)
+    #(5 4 7 6 1 0 3 2 13 12 15 14 9 8 11 10)
+    #(6 7 4 5 2 3 0 1 14 15 12 13 10 11 8 9)
+    #(7 6 5 4 3 2 1 0 15 14 13 12 11 10 9 8)
+    #(8 9 10 11 12 13 14 15 0 1 2 3 4 5 6 7)
+    #(9 8 11 10 13 12 15 14 1 0 3 2 5 4 7 6)
+    #(10 11 8 9 14 15 12 13 2 3 0 1 6 7 4 5)
+    #(11 10 9 8 15 14 13 12 3 2 1 0 7 6 5 4)
+    #(12 13 14 15 8 9 10 11 4 5 6 7 0 1 2 3)
+    #(13 12 15 14 9 8 11 10 5 4 7 6 1 0 3 2)
+    #(14 15 12 13 10 11 8 9 6 7 4 5 2 3 0 1)
+    #(15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0)))
+
+(define logical:boole-and
+ '#(#(0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0)
+    #(0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1)
+    #(0 0 2 2 0 0 2 2 0 0 2 2 0 0 2 2)
+    #(0 1 2 3 0 1 2 3 0 1 2 3 0 1 2 3)
+    #(0 0 0 0 4 4 4 4 0 0 0 0 4 4 4 4)
+    #(0 1 0 1 4 5 4 5 0 1 0 1 4 5 4 5)
+    #(0 0 2 2 4 4 6 6 0 0 2 2 4 4 6 6)
+    #(0 1 2 3 4 5 6 7 0 1 2 3 4 5 6 7)
+    #(0 0 0 0 0 0 0 0 8 8 8 8 8 8 8 8)
+    #(0 1 0 1 0 1 0 1 8 9 8 9 8 9 8 9)
+    #(0 0 2 2 0 0 2 2 8 8 10 10 8 8 10 10)
+    #(0 1 2 3 0 1 2 3 8 9 10 11 8 9 10 11)
+    #(0 0 0 0 4 4 4 4 8 8 8 8 12 12 12 12)
+    #(0 1 0 1 4 5 4 5 8 9 8 9 12 13 12 13)
+    #(0 0 2 2 4 4 6 6 8 8 10 10 12 12 14 14)
+    #(0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15)))
+
+(define (logical:ash-4 x)
+  (if (negative? x)
+      (+ -1 (quotient (+ 1 x) 16))
+      (quotient x 16)))
+
+(define (logical:reduce op4 ident)
+  (lambda args
+    (do ((res ident (op4 res (car rgs) 1 0))
+         (rgs args (cdr rgs)))
+        ((null? rgs) res))))
+
+;@
+(define logand
+  (letrec
+      ((lgand
+        (lambda (n2 n1 scl acc)
+          (cond ((= n1 n2) (+ acc (* scl n1)))
+                ((zero? n2) acc)
+                ((zero? n1) acc)
+                (else (lgand (logical:ash-4 n2)
+                             (logical:ash-4 n1)
+                             (* 16 scl)
+                             (+ (* (vector-ref (vector-ref logical:boole-and
+                                                           (modulo n1 16))
+                                               (modulo n2 16))
+                                   scl)
+                                acc)))))))
+    (logical:reduce lgand -1)))
+;@
+(define logior
+  (letrec
+      ((lgior
+        (lambda (n2 n1 scl acc)
+          (cond ((= n1 n2) (+ acc (* scl n1)))
+                ((zero? n2) (+ acc (* scl n1)))
+                ((zero? n1) (+ acc (* scl n2)))
+                (else (lgior (logical:ash-4 n2)
+                             (logical:ash-4 n1)
+                             (* 16 scl)
+                             (+ (* (- 15 (vector-ref
+                                          (vector-ref logical:boole-and
+                                                      (- 15 (modulo n1 16)))
+                                          (- 15 (modulo n2 16))))
+                                   scl)
+                                acc)))))))
+    (logical:reduce lgior 0)))
+;@
+(define logxor
+  (letrec
+      ((lgxor
+        (lambda (n2 n1 scl acc)
+          (cond ((= n1 n2) acc)
+                ((zero? n2) (+ acc (* scl n1)))
+                ((zero? n1) (+ acc (* scl n2)))
+                (else (lgxor (logical:ash-4 n2)
+                             (logical:ash-4 n1)
+                             (* 16 scl)
+                             (+ (* (vector-ref (vector-ref logical:boole-xor
+                                                           (modulo n1 16))
+                                               (modulo n2 16))
+                                   scl)
+                                acc)))))))
+    (logical:reduce lgxor 0)))
+;@
+(define (lognot n) (- -1 n))
+;@
+(define (logtest n1 n2)
+  (not (zero? (logand n1 n2))))
+;@
+(define (logbit? index n)
+  (logtest (expt 2 index) n))
+;@
+(define (copy-bit index to bool)
+  (if bool
+      (logior to (arithmetic-shift 1 index))
+      (logand to (lognot (arithmetic-shift 1 index)))))
+;@
+(define (bitwise-if mask n0 n1)
+  (logior (logand mask n0)
+          (logand (lognot mask) n1)))
+;@
+(define (bit-field n start end)
+  (logand (lognot (ash -1 (- end start)))
+          (arithmetic-shift n (- start))))
+;@
+(define (copy-bit-field to from start end)
+  (bitwise-if (arithmetic-shift (lognot (ash -1 (- end start))) start)
+              (arithmetic-shift from start)
+              to))
+;@
+(define (rotate-bit-field n count start end)
+  (define width (- end start))
+  (set! count (modulo count width))
+  (let ((mask (lognot (ash -1 width))))
+    (define zn (logand mask (arithmetic-shift n (- start))))
+    (logior (arithmetic-shift
+             (logior (logand mask (arithmetic-shift zn count))
+                     (arithmetic-shift zn (- count width)))
+             start)
+            (logand (lognot (ash mask start)) n))))
+;@
+(define (arithmetic-shift n count)
+  (if (negative? count)
+      (let ((k (expt 2 (- count))))
+        (if (negative? n)
+            (+ -1 (quotient (+ 1 n) k))
+            (quotient n k)))
+      (* (expt 2 count) n)))
+;@
+(define integer-length
+  (letrec ((intlen (lambda (n tot)
+                     (case n
+                       ((0 -1) (+ 0 tot))
+                       ((1 -2) (+ 1 tot))
+                       ((2 3 -3 -4) (+ 2 tot))
+                       ((4 5 6 7 -5 -6 -7 -8) (+ 3 tot))
+                       (else (intlen (logical:ash-4 n) (+ 4 tot)))))))
+    (lambda (n) (intlen n 0))))
+;@
+(define logcount
+  (letrec ((logcnt (lambda (n tot)
+                     (if (zero? n)
+                         tot
+                         (logcnt (quotient n 16)
+                                 (+ (vector-ref
+                                     '#(0 1 1 2 1 2 2 3 1 2 2 3 2 3 3 4)
+                                     (modulo n 16))
+                                    tot))))))
+    (lambda (n)
+      (cond ((negative? n) (logcnt (lognot n) 0))
+            ((positive? n) (logcnt n 0))
+            (else 0)))))
+;@
+(define (log2-binary-factors n)
+  (+ -1 (integer-length (logand n (- n)))))
+
+(define (bit-reverse k n)
+  (do ((m (if (negative? n) (lognot n) n) (arithmetic-shift m -1))
+       (k (+ -1 k) (+ -1 k))
+       (rvs 0 (logior (arithmetic-shift rvs 1) (logand 1 m))))
+      ((negative? k) (if (negative? n) (lognot rvs) rvs))))
+;@
+(define (reverse-bit-field n start end)
+  (define width (- end start))
+  (let ((mask (lognot (ash -1 width))))
+    (define zn (logand mask (arithmetic-shift n (- start))))
+    (logior (arithmetic-shift (bit-reverse width zn) start)
+            (logand (lognot (ash mask start)) n))))
+;@
+(define (integer->list k . len)
+  (if (null? len)
+      (do ((k k (arithmetic-shift k -1))
+           (lst '() (cons (odd? k) lst)))
+          ((<= k 0) lst))
+      (do ((idx (+ -1 (car len)) (+ -1 idx))
+           (k k (arithmetic-shift k -1))
+           (lst '() (cons (odd? k) lst)))
+          ((negative? idx) lst))))
+;@
+(define (list->integer bools)
+  (do ((bs bools (cdr bs))
+       (acc 0 (+ acc acc (if (car bs) 1 0))))
+      ((null? bs) acc)))
+(define (booleans->integer . bools)
+  (list->integer bools))
+
+;;;;@ SRFI-60 aliases
+(define ash arithmetic-shift)
+(define bitwise-ior logior)
+(define bitwise-xor logxor)
+(define bitwise-and logand)
+(define bitwise-not lognot)
+(define bit-count logcount)
+(define bit-set?   logbit?)
+(define any-bits-set? logtest)
+(define first-set-bit log2-binary-factors)
+(define bitwise-merge bitwise-if)
+
+;;; Legacy
+;;(define (logical:rotate k count len) (rotate-bit-field k count 0 len))
+;;(define (logical:ones deg) (lognot (ash -1 deg)))
+;;(define integer-expt expt)            ; legacy name

--- a/srfi-60/test/srfi-60-tests.scm
+++ b/srfi-60/test/srfi-60-tests.scm
@@ -1,0 +1,188 @@
+(import (chibi) (chibi test) (srfi 60))
+
+(test-begin "srfi-60")
+
+(test-group "Bitwise Operations"
+  (test 5 (bitwise-and 5))
+  (test #b1000 (bitwise-and #b1100 #b1010))
+  (test #b0100 (bitwise-and #b0100 #b0110 #b0110 #b0101 #b1101 #b0111))
+
+  (test 9 (bitwise-ior 9))
+  (test #b1110 (bitwise-ior #b1100 #b1010))
+  (test #b1011 (bitwise-ior #b0001 #b0000 #b1010 #b1001 #b1010 #b1000))
+
+  (test -3 (bitwise-xor -3))
+  (test #b0110 (bitwise-xor #b1100 #b1010))
+  (test #b1100 (bitwise-xor #b0101 #b1110 #b0001 #b1010 #b0101 #b1001))
+
+  (test  0 (bitwise-not -1))
+  (test -1 (bitwise-not  0))
+  (test -2 (bitwise-not  1))
+  (test (- #b0110011) (bitwise-not #b110010))
+  (test #b011001 (bitwise-and #b111111 (bitwise-not #b100110)))
+  (test 1278781 (bitwise-not (bitwise-not 1278781)))
+
+  (test #b0101 (bitwise-if #b1111 #b0101 #b1010))
+  (test #b1010 (bitwise-if #b0000 #b0101 #b1010))
+  (test #b1100 (bitwise-if #b1100 #b1111 #b0000))
+  (test #b1011 (bitwise-if #b1010 #b1111 #b0011))
+  (test #b11001010 (bitwise-if #b11110000 #b11001100 #b10101010))
+
+  (test #f (any-bits-set? #b0100 #b1011))
+  (test #t (any-bits-set? #b0100 #b0111))
+  (test #t (any-bits-set? #b0101 #b0111))
+  (test #f (any-bits-set? #b0101 #b1010)))
+
+(test-group "Integer Properties"
+  (test 0 (bit-count 0))
+  (test 1 (bit-count 1))
+  (test 1 (bit-count 2))
+  (test 2 (bit-count 3))
+  (test 7 (bit-count #b1011101101))
+  (test 1 (bit-count -3)) ; -3 = #b1...101
+  (test 2 (bit-count -4)) ; -4 = #b1...100
+  (test 1 (bit-count -5)) ; -5 = #b1...011
+
+  (test 0 (integer-length 0))
+  (test 1 (integer-length 1))
+  (test 2 (integer-length 2))
+  (test 2 (integer-length 3))
+  (test 3 (integer-length 4))
+  (test 3 (integer-length 5))
+  (test 4 (integer-length 8))
+  (test 4 (integer-length #b1111))
+  (test 3 (integer-length #b0111))
+  (test 6 (integer-length -42)) ; -42 = #b1...010110
+  (test #t (= (integer-length 178963123) (integer-length -178963123)))
+
+  (test -1 (first-set-bit 0))
+  (test 0 (first-set-bit  1))  (test 0 (first-set-bit  -1))
+  (test 1 (first-set-bit  2))  (test 1 (first-set-bit  -2))
+  (test 0 (first-set-bit  3))  (test 0 (first-set-bit  -3))
+  (test 2 (first-set-bit  4))  (test 2 (first-set-bit  -4))
+  (test 0 (first-set-bit  5))  (test 0 (first-set-bit  -5))
+  (test 1 (first-set-bit  6))  (test 1 (first-set-bit  -6))
+  (test 0 (first-set-bit  7))  (test 0 (first-set-bit  -7))
+  (test 3 (first-set-bit  8))  (test 3 (first-set-bit  -8))
+  (test 0 (first-set-bit  9))  (test 0 (first-set-bit  -9))
+  (test 1 (first-set-bit 10))  (test 1 (first-set-bit -10))
+  (test 0 (first-set-bit 11))  (test 0 (first-set-bit -11))
+  (test 2 (first-set-bit 12))  (test 2 (first-set-bit -12))
+  (test 0 (first-set-bit 13))  (test 0 (first-set-bit -13))
+  (test 1 (first-set-bit 14))  (test 1 (first-set-bit -14))
+  (test 0 (first-set-bit 15))  (test 0 (first-set-bit -15))
+  (test 4 (first-set-bit 16))  (test 4 (first-set-bit -16)))
+
+(test-group "Bit Within Word"
+  (test #t (bit-set? 0 #b1101))
+  (test #f (bit-set? 1 #b1101))
+  (test #t (bit-set? 2 #b1101))
+  (test #t (bit-set? 3 #b1101))
+  (test #f (bit-set? 4 #b1101))
+
+  (test #f (bit-set? 0 -6)) ; -6 = #b1...010
+  (test #t (bit-set? 1 -6))
+  (test #f (bit-set? 2 -6))
+  (test #t (bit-set? 3 -6))
+  (test #t (bit-set? 4 -6))
+
+  (test #f (bit-set? 0 0))
+  (test #f (bit-set? 1 0))
+  (test #f (bit-set? 2 0))
+
+  (test #b0001 (copy-bit 0 #b0000 #t))
+  (test #b0100 (copy-bit 2 #b0000 #t))
+  (test #b1011 (copy-bit 2 #b1111 #f))
+  (test #b0000 (copy-bit 0 #b0000 #f))
+  (test #b1101 (copy-bit 3 #b1101 #t))
+  (test (bitwise-not #b1101) (copy-bit 2 (bitwise-not #b1001) #f)))
+
+(test-group "Field of Bits"
+  (test #b01010 (bit-field #b1101101010 0 4))
+  (test #b00101 (bit-field #b1101101010 1 5))
+  (test #b11010 (bit-field #b1101101010 2 7))
+  (test #b01101 (bit-field #b1101101010 3 8))
+  (test #b10110 (bit-field #b1101101010 4 9))
+  (test #b00000 (bit-field #b1101101010 5 5))
+
+  (test #b000001101100000 (copy-bit-field #b000001101101010  0 0 4))
+  (test #b000001101101111 (copy-bit-field #b000001101101010 -1 0 4))
+  (test #b110100111110000 (copy-bit-field #b110100100010000 -1 5 9))
+  (test #b1101000 (copy-bit-field 0 #b11101101 3 7))
+  (test #b1100100 (copy-bit-field #b1100000 #b11101101 2 4))
+  (test #b1110110101 (copy-bit-field #b1 #b11101101 2 10))
+
+  (test #b1000 (arithmetic-shift #b0001  3))
+  (test #b1010 (arithmetic-shift #b1010  0))
+  (test #b0101 (arithmetic-shift #b1010 -1))
+  (test #b0000 (arithmetic-shift #b0011 -2))
+  (test (bitwise-not #b0000) (arithmetic-shift (bitwise-not #b0011) -2))
+  (test (bitwise-not #b101111) (arithmetic-shift (bitwise-not #b1011) 2))
+
+  (test #b10 (rotate-bit-field #b0100  3 0 4))
+  (test #b10 (rotate-bit-field #b0100 -1 0 4))
+  (test #b110100010010000 (rotate-bit-field #b110100100010000 -1 5 9))
+  (test #b110100000110000 (rotate-bit-field #b110100100010000  1 5 9))
+  (test #b11110110 (rotate-bit-field #b11101101 -1 0 8))
+  (test #b11101101 (rotate-bit-field #b11101101  0 0 8))
+  (test #b11011011 (rotate-bit-field #b11101101  1 0 8))
+  (test #b10110111 (rotate-bit-field #b11101101  2 0 8))
+  (test #b01101111 (rotate-bit-field #b11101101  3 0 8))
+  (test #b11011110 (rotate-bit-field #b11101101  4 0 8))
+  (test #b10111101 (rotate-bit-field #b11101101  5 0 8))
+  (test #b11011101 (rotate-bit-field #b11101101  6 3 8))
+  (test #b11011011 (rotate-bit-field #b11101101 65 0 8))
+  (test #b11101101 (rotate-bit-field #b11101101  4 1 1))
+
+  (test #xe5 (reverse-bit-field #xa7 0 8))
+  (test #b10110111 (reverse-bit-field #b11101101 0 8))
+  (test #b11101101 (reverse-bit-field #b11101101 3 3))
+  (test #b11101011 (reverse-bit-field #b11101101 0 4))
+  (test #b00000000 (reverse-bit-field #b00000000 3 6))
+  (test #b11111101 (reverse-bit-field #b11111101 0 1)))
+
+(test-group "Bits as Booleans"
+  (test '(#t #t #f #t #f #t #t #f #t) (integer->list #b110101101))
+  (test '()      (integer->list 0))
+  (test '(#t)    (integer->list 1))
+  (test '(#t #f) (integer->list 2))
+  (test '(#t #t) (integer->list 3))
+  (test '(#t #f #t #f #t #f #f) (integer->list 84))
+  (test                     '() (integer->list 84 0))
+  (test             '(#t #f #f) (integer->list 84 3))
+  (test    '(#f #t #f #t #f #f) (integer->list 84 6))
+  (test '(#f #f #f #f #f
+          #t #f #t #f #t #f #f) (integer->list 84 12))
+
+  (test #b110101101 (list->integer '(#t #t #f #t #f #t #t #f #t)))
+  (test 0 (list->integer '()))
+  (test 1 (list->integer '(#t)))
+  (test 2 (list->integer '(#t #f)))
+  (test 3 (list->integer '(#t #t)))
+  (test 84 (list->integer                '(#t #f #t #f #t #f #f)))
+  (test 84 (list->integer '(#f #f #f #f #f #t #f #t #f #t #f #f)))
+
+  (test #b110101101 (booleans->integer #t #t #f #t #f #t #t #f #t))
+  (test 0 (booleans->integer))
+  (test 1 (booleans->integer #t))
+  (test 2 (booleans->integer #t #f))
+  (test 3 (booleans->integer #t #t))
+  (test 84 (booleans->integer                #t #f #t #f #t #f #f))
+  (test 84 (booleans->integer #f #f #f #f #f #t #f #t #f #t #f #f)))
+
+;; It would be too stupid to test these as real procedures
+(test-group "Aliases"
+  (test-assert (eqv? bitwise-and logand))
+  (test-assert (eqv? bitwise-ior logior))
+  (test-assert (eqv? bitwise-xor logxor))
+  (test-assert (eqv? bitwise-not lognot))
+  (test-assert (eqv? first-set-bit log2-binary-factors))
+  (test-assert (eqv? any-bits-set? logtest))
+  (test-assert (eqv? bitwise-if bitwise-merge))
+  (test-assert (eqv? bit-count logcount))
+  (test-assert (eqv? bit-set? logbit?))
+  (test-assert (eqv? arithmetic-shift ash)))
+
+(test-end)
+
+(test-exit)

--- a/tools/install-chibi
+++ b/tools/install-chibi
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -ex
+
+cd /tmp/scratch
+hg clone https://code.google.com/p/chibi-scheme/
+
+cd chibi-scheme
+make -j$(expr $(nproc) + 1)
+make test-all
+
+sudo make install

--- a/tools/install-self
+++ b/tools/install-self
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -ex
+
+chibi_install_dir=/usr/local/share/chibi
+
+sudo mkdir $chibi_install_dir/srfi/60
+
+sudo install --mode=0644 $(find ./srfi-60/srfi    -maxdepth 1 -type f) $chibi_install_dir/srfi
+sudo install --mode=0644 $(find ./srfi-60/srfi/60 -maxdepth 1 -type f) $chibi_install_dir/srfi/60
+
+sudo chown --recursive root $chibi_install_dir/srfi/60

--- a/tools/run-all-tests
+++ b/tools/run-all-tests
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -ex
+
+chibi-scheme ./srfi-60/test/srfi-60-tests.scm


### PR DESCRIPTION
Resolves issue #1.

This adds a reference implementation and a test-set for it. Funny thing, I have found a bug in the reference implementation. So nevermind the build error.

I thought about including some bignum tests, but then decided to not do it. The tests must be portable and Schemes are not required to support bignums. Assuming that they do support at least 20-ish bits for fixnums seems to be reasonable enough.
